### PR TITLE
Recognize flags contained in the env vars `RUST{,DOC}FLAGS`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ dependencies = [
  "owo-colors",
  "ra-ap-rustc_lexer",
  "rustc-hash",
+ "shlex",
  "smallvec",
 ]
 
@@ -234,6 +235,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ open = "5.0.0"
 owo-colors = { version = "4.0.0-rc.1", features = ["supports-colors"] }
 ra-ap-rustc_lexer = "0.34.0"
 rustc-hash = "1.1.0"
+shlex = "1.3.0"
 smallvec = { version = "1.13.1", features = ["const_generics"] }
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -71,21 +71,23 @@ Lastly, *rrustdoc* defaults to the CSS theme *Ayu* because it's a dark theme and
 
 This mode is entirely separate from the default & the cross-crate build mode.
 
-> **FIXME**: Expand upon this section.
+<!-- FIXME: Expand upon this section. -->
 
-*rrustdoc* natively understands the following [`ui_test`]-style [`compiletest`] directives: `aux-build`, `aux-crate`, `build-aux-docs`, `compile-flags`, `edition`, `force-host` (**FIXME**: Well, we ignore it right now), `no-prefer-dynamic` (**FIXME**: Well, we ignore it right now), `revisions`, `rustc-env` and `unset-rustc-env`. Any other directives get skipped and *rrustdoc* emits a warning for the sake of transparency. This selection should suffice, it should cover the majority of use cases. We intentionally don't support `{unset-,}exec-env` since it's not meaningful.
+*rrustdoc* natively understands the following [`ui_test`]-style [`compiletest`] directives: `aux-build`, `aux-crate`, `build-aux-docs`, `compile-flags`, `edition`, `force-host`<!-- FIXME: Well, we ignore it right now -->, `no-prefer-dynamic`<!-- FIXME: Well, we ignore it right now -->, `revisions`, `rustc-env` and `unset-rustc-env`. Any other directives get skipped and *rrustdoc* emits a warning for the sake of transparency. This selection should suffice, it should cover the majority of use cases. We intentionally don't support `{,unset-}exec-env` since it's not meaningful.
 
 *rrustdoc* has *full* support for *revisions*. You can pass `--rev ⟨NAME⟩` or `--cfg ⟨SPEC⟩` to enable individual revisions. The former is checked against the revisions declared by `//@ revisions`, the latter is *not*. In the future, *rrustdoc* will have support for `--all-revs` (executing `rrustdoc` (incl. `--open`) for all declared revisions; useful for swiftly comparing minor changes to the source code).
 
 ### Features Common Across Build Modes
 
-For convenience, you can pass `-f`/`--cargo-feature` `⟨NAME⟩` to enable a *Cargo*-like feature, i.e., a `cfg` that can be checked for with `#[cfg(feature = "⟨NAME⟩")]` and similar in the source code. `-f ⟨NAME⟩` just expands to `--cfg feature="⟨NAME⟩"` (modulo shell escaping).
+Yu can pass the convenience flag `-f`/`--cargo-feature` `⟨NAME⟩` to enable a *Cargo*-like feature, i.e., a `cfg` that can be checked for with `#[cfg(feature = "⟨NAME⟩")]` and similar in the source code. `-f ⟨NAME⟩` just expands to `--cfg feature="⟨NAME⟩"` (modulo shell escaping).
 
-For convenience, you can pass `-F`/`--rustc-feature` `⟨NAME⟩` to enable an experimental rustc library or language feature. It just expands to `rust{c,doc}`'s `-Zcrate-attr=feature(⟨NAME⟩)` (modulo shell escaping). For example, you can pass `-Flazy_type_alias` to quickly enable *[lazy type aliases]*.
+You can pass the convenience flag `-F`/`--rustc-feature` `⟨NAME⟩` to enable an experimental rustc library or language feature. It just expands to `rust{c,doc}`'s `-Zcrate-attr=feature(⟨NAME⟩)` (modulo shell escaping). For example, you can pass `-Flazy_type_alias` to quickly enable *[lazy type aliases]*.
 
-To set the *[rustup]* toolchain, you use `-t`. Examples: `rrustdoc file.rs -tnightly`, `rrustdoc file.rs -tstage2`. Currently, you *cannot* use the *rustup*-style `+⟨TOOLCHAIN⟩` flag unfortunately. I plan on adding support for that if there's an easy way to do it with `clap` (the CLI parser we use).
+To set the *[rustup]* toolchain, you use `-t`. Examples: `rrustdoc file.rs -tnightly`, `rrustdoc file.rs -tstage2`. Currently, you *cannot* use the *rustup*-style `+⟨TOOLCHAIN⟩` flag unfortunately. I plan on adding support for that if there's an easy way to do it with *clap* (the CLI parser we use).
 
 If you'd like to know the precise commands *rrustdoc* runs under the hood for example to be able to open a rust-lang/rust GitHub issue with proper reproduction steps, pass `-V`/`--verbose` and look for output of the form `note: running `. *rrustdoc* tries very hard to minimize the amount of flags passed to `rust{c,doc}` exactly for the aforementioned use case. It's not perfect, you might be able to remove some flags for the reproducer (you can definitely get rid of `--default-theme=ayu` :D).
+
+Just like *Cargo*, *rrustdoc* recognizes the environment variables `RUSTFLAGS` and `RUSTDOCFLAGS`. The arguments / flags present in these flags get passed *verbatim* (modulo shell escaping) to `rustc` and `rustdoc` respectively. Be aware that the flags you pass *may conflict* with the ones added by *rrustdoc* but as mentioned in the paragraph above, it tries fiercely not to add flags unnecessarily. Note that your flags get added last. You can debug potential conflicts by passing `-V`/`--verbose` to `rrustdoc` and by looking for lines starting with `note: running ` in the output to get to know first hand what `rrustdoc` tried to pass to the underlying programs.
 
 ## Command-Line Interface
 
@@ -129,6 +131,8 @@ Options:
       --color <WHEN>             Control when to use color [default: auto] [possible values: auto, always, never]
   -h, --help                     Print help
 ```
+
+Additionally, *rrustdoc* recognizes the environment variables `RUSTFLAGS` and `RUSTDOCFLAGS`.
 
 ## License
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,6 +7,7 @@
 // the commands printed by `--verbose` for use in GitHub discussions without requiring any
 // manual minimization.
 // FIXME: Also mention to reduce conflicts with compile flags passed via `compiletest`
+//        as well as those passed via the `RUST{,DOC}FLAGS` env vars.
 
 use crate::{
     cli,
@@ -23,6 +24,8 @@ use std::{
     process,
     str::FromStr,
 };
+
+mod environment;
 
 pub(crate) fn compile(
     path: &Path,
@@ -54,6 +57,11 @@ pub(crate) fn compile(
     command.set_internals_mode(build_flags);
 
     command.set_verbatim_flags(verbatim_flags);
+
+    if let Some(flags) = &*environment::RUSTFLAGS {
+        command.args(flags);
+    }
+
     command.execute()
 }
 
@@ -126,6 +134,11 @@ pub(crate) fn document(
     command.set_internals_mode(build_flags);
 
     command.set_verbatim_flags(verbatim_flags);
+
+    if let Some(flags) = &*environment::RUSTDOCFLAGS {
+        command.args(flags);
+    }
+
     command.execute()
 }
 

--- a/src/command/environment.rs
+++ b/src/command/environment.rs
@@ -1,0 +1,71 @@
+use crate::utility::Tag;
+use rustc_hash::FxHashMap;
+use std::{
+    ffi::{OsStr, OsString},
+    sync::LazyLock,
+};
+
+type Environment = FxHashMap<OsString, OsString>;
+type Flags = Vec<String>;
+
+pub(crate) static RUSTFLAGS: LazyLock<Option<Flags>> = LazyLock::new(|| {
+    parse_flags(
+        OsStr::new("RUSTFLAGS"),
+        &[
+            OsStr::new("RUST_FLAGS"),
+            OsStr::new("RUSTCFLAGS"),
+            OsStr::new("RUSTC_FLAGS"),
+        ],
+        &ENVIRONMENT,
+    )
+});
+
+pub(crate) static RUSTDOCFLAGS: LazyLock<Option<Flags>> = LazyLock::new(|| {
+    parse_flags(
+        OsStr::new("RUSTDOCFLAGS"),
+        &[OsStr::new("RUSTDOC_FLAGS")],
+        &ENVIRONMENT,
+    )
+});
+
+static ENVIRONMENT: LazyLock<Environment> = LazyLock::new(|| std::env::vars_os().collect());
+
+fn parse_flags(key: &OsStr, confusables: &[&OsStr], environment: &Environment) -> Option<Flags> {
+    for &confusable in confusables {
+        if environment.contains_key(confusable) {
+            eprintln!(
+                "{}rrustdoc does not read the `{}` environment variable; \
+                 you might have meant `{}`",
+                Tag::Warning,
+                confusable.display(),
+                key.display(),
+            );
+        }
+    }
+
+    let flags = environment.get(key)?;
+
+    let Some(flags) = flags.to_str() else {
+        eprintln!(
+            "{}the environment variable `{}` does not contain valid UTF-8; \
+                ignoring all potential flags",
+            Tag::Warning,
+            key.display(),
+        );
+
+        return None;
+    };
+
+    let flags = shlex::split(&flags);
+
+    if flags.is_none() {
+        eprintln!(
+            "{}the environment variable `{}` is not well-formed; \
+             ignoring all potential flags",
+            Tag::Warning,
+            key.display(),
+        );
+    }
+
+    flags
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@
     exit_status_error,
     type_alias_impl_trait,
     lazy_cell,
-    byte_slice_trim_ascii
+    byte_slice_trim_ascii,
+    os_str_display
 )]
 
 use crate::utility::Tag;
@@ -23,8 +24,6 @@ mod parser;
 mod utility;
 
 // FIXME: respect `compile-flags: --test`
-// FIXME: Support passing additional arguments verbatim to `rustc` & `rustdoc`
-//        via `RUSTFLAGS`/`RUSTDOCFLAGS`.
 // FIXME: Add `--all-revs`.
 
 fn main() -> ExitCode {


### PR DESCRIPTION
Fixes #5.